### PR TITLE
fix: 不完全リンクによるpanicを修正

### DIFF
--- a/adapter/adapter_test.go
+++ b/adapter/adapter_test.go
@@ -152,6 +152,10 @@ func TestLinkLinkAndText(t *testing.T) {
 	CommonExecuter("link/link_and_text", t)
 }
 
+func TestLinkText(t *testing.T) {
+	CommonExecuter("link/text", t)
+}
+
 // image
 func TestImageSimple(t *testing.T) {
 	CommonExecuter("image/simple", t)

--- a/parser/parse_image.go
+++ b/parser/parse_image.go
@@ -6,7 +6,10 @@ import (
 
 func parseImage(token *lexer.Token) (*Node, *lexer.Token) {
 	node, curToken := parseLink(token.Next)
-	node.Kind = ND_IMAGE
-
+	if node.Kind == ND_LINK {
+		node.Kind = ND_IMAGE
+	} else {
+		node.Value = "!" + node.Value
+	}
 	return node, curToken
 }

--- a/parser/parse_link.go
+++ b/parser/parse_link.go
@@ -25,7 +25,7 @@ func parseLink(token *lexer.Token) (*Node, *lexer.Token) {
 			link += curToken.Value
 			curToken = curToken.Next
 			if exepct(curToken, lexer.SEPARATE, "\n") {
-				value := fmt.Sprintf("[%s](%s)", display, link)
+				value := fmt.Sprintf("[%s](%s", display, link)
 				node = NewNode(ND_VALUE, value, 0, 0)
 				return node, curToken
 			}

--- a/parser/parse_link.go
+++ b/parser/parse_link.go
@@ -14,12 +14,21 @@ func parseLink(token *lexer.Token) (*Node, *lexer.Token) {
 	for curToken != nil && !exepct(curToken, lexer.RESERVED, "]") {
 		display += curToken.Value
 		curToken = curToken.Next
+		if exepct(curToken, lexer.SEPARATE, "\n") {
+			node = NewNode(ND_VALUE, "["+display, 0, 0)
+			return node, curToken
+		}
 	}
 	if expectNext(curToken, lexer.RESERVED, "(") {
 		curToken = seek(curToken, 2) // ]と(の2つ分
 		for curToken != nil && !exepct(curToken, lexer.RESERVED, ")") {
 			link += curToken.Value
 			curToken = curToken.Next
+			if exepct(curToken, lexer.SEPARATE, "\n") {
+				value := fmt.Sprintf("[%s](%s)", display, link)
+				node = NewNode(ND_VALUE, value, 0, 0)
+				return node, curToken
+			}
 		}
 		node = NewNode(ND_LINK, link, 0, 0)
 		node.Nest = NewNode(ND_VALUE, display, 0, 0)

--- a/static/html/image/text.html
+++ b/static/html/image/text.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>Generate html from markdown!</title>
+</head>
+<body>
+<p>![sample</p>
+<p>![sample](https://uploads-ssl.webflow.com/603c87adb15be3cb0b3ed9b5/60f95161b382b3c00f3b3057_80_cat_box_ol.png</p>
+</body>
+</html>

--- a/static/html/link/text.html
+++ b/static/html/link/text.html
@@ -1,0 +1,9 @@
+<html>
+<head>
+<title>Generate html from markdown!</title>
+</head>
+<body>
+<p>[google</p>
+<p>[google]](https://google.com</p>
+</body>
+</html>

--- a/static/md/image/text.md
+++ b/static/md/image/text.md
@@ -1,0 +1,2 @@
+![sample
+![sample](https://uploads-ssl.webflow.com/603c87adb15be3cb0b3ed9b5/60f95161b382b3c00f3b3057_80_cat_box_ol.png

--- a/static/md/link/text.md
+++ b/static/md/link/text.md
@@ -1,0 +1,3 @@
+[google
+[google]](https://google.com
+


### PR DESCRIPTION
`![sample](https://google.com`のような不完全なリンクによってpanicが発生していたので修正しました。